### PR TITLE
Add Caddy reverse proxy and maintenance script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ volumes:
 
 networks:
   bridge:
+  caddy:
+    external: true
 
 x-n8n: &service-n8n
   image: n8nio/n8n:latest
@@ -95,8 +97,17 @@ services:
     <<: *service-n8n
     container_name: n8n
     restart: unless-stopped
-    ports:
-      - 5678:5678
+    environment:
+      - N8N_HOST=n8n.fuentefunding.com
+      - N8N_PROTOCOL=https
+      - N8N_PORT=5678
+      - NODE_ENV=production
+      - WEBHOOK_URL=https://n8n.fuentefunding.com/
+    networks:
+      - bridge
+      - caddy
+    expose:
+      - "5678"
     volumes:
       - n8n_storage:/home/node/.n8n
       - ./n8n/backup:/backup

--- a/proxy/Caddyfile
+++ b/proxy/Caddyfile
@@ -1,0 +1,23 @@
+n8n.fuentefunding.com {
+    reverse_proxy n8n:5678 {
+        header_up X-Real-IP {remote_host}
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto {scheme}
+    }
+
+    log {
+        output file /var/log/caddy/n8n.access.log
+    }
+
+    tls {
+        protocols tls1.2 tls1.3
+    }
+
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options "nosniff"
+        Referrer-Policy "strict-origin-when-cross-origin"
+        X-XSS-Protection "1; mode=block"
+        X-Frame-Options "SAMEORIGIN"
+    }
+}

--- a/proxy/docker-compose.caddy.yml
+++ b/proxy/docker-compose.caddy.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+networks:
+  caddy:
+    external: true
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - caddy
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+      - ./logs/caddy:/var/log/caddy
+    environment:
+      - CADDY_DOMAIN=n8n.fuentefunding.com
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/scripts/maintenance.sh
+++ b/scripts/maintenance.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+apt update && apt upgrade -y
+docker system prune -af --volumes
+docker-compose up n8n-backup
+docker-compose down
+docker-compose up -d


### PR DESCRIPTION
This PR adds Caddy as a reverse proxy for n8n and implements a maintenance script. Changes include:

- Added Caddy configuration with TLS and security headers
- Created docker-compose file for Caddy service
- Updated n8n service configuration for proxy integration
- Added maintenance script for system updates and container management

Key features:
- Secure TLS configuration (TLS 1.2/1.3)
- Enhanced security headers (HSTS, XSS protection, etc.)
- Automated logging setup
- System maintenance and Docker cleanup script

The proxy setup enables secure HTTPS access to n8n through `n8n.fuentefunding.com` while the maintenance script helps keep the system updated and clean.